### PR TITLE
Fix Typos in Documentation Comments

### DIFF
--- a/API/instructions/instructions.with_called_function_name.md
+++ b/API/instructions/instructions.with_called_function_name.md
@@ -12,7 +12,7 @@ Adds a filter to get instructions that call a function with the given name.
 from glider import *
 
 def query():
-  # Fetch a list of intructions that call the "transfer" function
+  # Fetch a list of instructions that call the "transfer" function
   instructions = Instructions().with_called_function_name("transfer").exec(1)
 
   return instructions

--- a/api/arguments/convertor/convertor.set_conversions.md
+++ b/api/arguments/convertor/convertor.set_conversions.md
@@ -20,7 +20,7 @@ def query():
   # Fetch a list of functions
   funs = Functions().exec(10)
 
-  # Return the functions with at least one argument converitble to bytes20
+  # Return the functions with at least one argument convertible to bytes20
   # It will be only the argument of type address
   output = []
   for fun in funs:


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in documentation comments within two files:
- In `API/instructions/instructions.with_called_function_name.md`, the word "intructions" was corrected to "instructions".
- In `api/arguments/convertor/convertor.set_conversions.md`, the word "convertible" was corrected in the comment for clarity.

No functional code changes were made; only comments were updated for accuracy and readability.
